### PR TITLE
Add backend chatbot module and configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Proyecto
+
+## Backend
+
+Para iniciar el servidor backend:
+
+1. Instala las dependencias:
+   ```bash
+   cd backend
+   npm install
+   ```
+2. Arranca el servidor:
+   ```bash
+   npm start
+   ```
+
+El servidor quedará disponible en [http://localhost:3001](http://localhost:3001).

--- a/backend/chatbot.js
+++ b/backend/chatbot.js
@@ -1,0 +1,8 @@
+function getResponse(message) {
+  if (!message) {
+    return 'No entendí tu mensaje.';
+  }
+  return `Recibí: ${message}`;
+}
+
+module.exports = { getResponse };

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "Backend del proyecto",
+  "main": "app.js",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "cors": "^2.8.5"
+  }
+}


### PR DESCRIPTION
## Summary
- add simple chatbot module for backend
- configure package.json for express and cors
- document backend start steps in README

## Testing
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/cors)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c0a5ce23dc832491f95d02c2a2938c