### PR TITLE
Add tests and testing scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -15,3 +15,18 @@ Para iniciar el servidor backend:
    ```
 
 El servidor quedará disponible en [http://localhost:3001](http://localhost:3001).
+
+### Pruebas
+
+Para ejecutar las pruebas del backend:
+
+```bash
+cd backend
+npm test
+```
+
+Para ejecutar las pruebas de la aplicación Flask:
+
+```bash
+make test
+```

--- a/backend/__tests__/app.test.js
+++ b/backend/__tests__/app.test.js
@@ -1,0 +1,13 @@
+const request = require('supertest');
+const app = require('../app');
+
+describe('POST /api/chat', () => {
+  it('responds with chatbot reply', async () => {
+    const res = await request(app)
+      .post('/api/chat')
+      .send({ message: 'Hola' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ response: 'Recibí: Hola' });
+  });
+});

--- a/backend/app.js
+++ b/backend/app.js
@@ -11,4 +11,8 @@ app.post('/api/chat', (req, res) => {
     res.json({ response });
 });
 
-app.listen(3001, () => console.log('Servidor en http://localhost:3001'));
+if (require.main === module) {
+    app.listen(3001, () => console.log('Servidor en http://localhost:3001'));
+}
+
+module.exports = app;

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,10 +4,15 @@
   "description": "Backend del proyecto",
   "main": "app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "test": "jest"
   },
   "dependencies": {
     "express": "^4.18.2",
     "cors": "^2.8.5"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   }
 }

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,47 @@
+import os
+import sys
+import pytest
+from types import SimpleNamespace
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from app import app, openai
+
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+
+def test_login_redirects_when_not_authorized(client, monkeypatch):
+    monkeypatch.setattr('app.google', SimpleNamespace(authorized=False))
+    response = client.get('/login')
+    assert response.status_code == 302
+
+
+def test_logout_clears_session(client):
+    with client.session_transaction() as sess:
+        sess['user'] = {'id': 1}
+    response = client.get('/logout')
+    assert response.status_code == 302
+    with client.session_transaction() as sess:
+        assert 'user' not in sess
+
+
+def test_chat_requires_login(client):
+    response = client.post('/chat', json={'message': 'hola'})
+    assert response.status_code == 401
+
+
+def test_chat_returns_reply(client, monkeypatch):
+    with client.session_transaction() as sess:
+        sess['user'] = {'id': 1}
+
+    class DummyCompletion:
+        choices = [SimpleNamespace(message=SimpleNamespace(content='respuesta'))]
+
+    monkeypatch.setattr(openai.ChatCompletion, 'create', lambda **kwargs: DummyCompletion())
+    response = client.post('/chat', json={'message': 'hola'})
+    assert response.status_code == 200
+    assert response.get_json()['reply'] == 'respuesta'


### PR DESCRIPTION
## Summary
- Export Express app and add Jest test for `/api/chat`
- Add pytest suite for `/login`, `/logout` and `/chat`
- Provide `npm test` and `make test` scripts with README instructions

## Testing
- `npm test` *(fails: jest not found)*
- `make test` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68c0c0c0af9c832496a64d5b8880d965